### PR TITLE
Add version number

### DIFF
--- a/Sources/gen-ir/Versions.swift
+++ b/Sources/gen-ir/Versions.swift
@@ -1,0 +1,12 @@
+//
+//  Versions.swift
+//  
+//
+//  Created by Thomas Hedderwick on 12/09/2022.
+//
+
+import Foundation
+
+enum Versions {
+	static let version = "0.1.1"
+}

--- a/Sources/gen-ir/gen_ir.swift
+++ b/Sources/gen-ir/gen_ir.swift
@@ -27,7 +27,8 @@ struct IREmitterCommand: ParsableCommand {
 
 		Example with pipe:
 			$ xcodebuild clean && xcodebuild build -project MyProject.xcodeproj -configuration Debug -scheme MyScheme 2>&1 | gen-sil - output_folder/
-		"""
+		""",
+		version: "v\(Versions.version)"
 	)
 
 	/// Path to an Xcode build log, or `-` if build log should be read from stdin


### PR DESCRIPTION
This change adds a version number to the tool so users can determine which version they are running. 