### PR TITLE
Remove the -fembed-bitcode flag if it's specified

### DIFF
--- a/Sources/gen-ir/CompilerCommandRunner.swift
+++ b/Sources/gen-ir/CompilerCommandRunner.swift
@@ -142,6 +142,8 @@ struct CompilerCommandRunner {
 			.replacingOccurrences(of: "-parseable-output ", with: "")
 		// for some reason this throws an error if included?
 			.replacingOccurrences(of: "-use-frontend-save-temps", with: "")
+		// if bitcode embedding is enabled, Clang will output.... textual ASM???? Why
+			.replacingOccurrences(of: "-fembed-bitcode", with: "")
 	}
 
 	/// Corrects the compiler arguments by removing options block BC generation and adding options to emit BC


### PR DESCRIPTION
If clang has the `-fembed-bitcode` flag on, and we pass flags to emit LLVM IR, Clang will........... emit textual ASM. 

Remove the `-fembed-flag`, `swiftc` doesn't have this probelm so we can leave `-embed-bitcode` intact and it'll be safely ignored.