### PR TITLE
Remove -fembed-bitcode flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,14 @@ jobs:
           echo "Found label: $LABEL"
 
           if [[ $LABEL == "merge-bump-major" ]]; then
-            echo "next_tag=$MAJOR_VERSION" >> $GITHUB_ENVIRONMENT
+            echo "next_tag=$MAJOR_VERSION" >> $GITHUB_ENV
           elif [[ $LABEL == "merge-bump-minor" ]]; then
-            echo "next_tag=$MINOR_VERSION" >> $GITHUB_ENVIRONMENT
+            echo "next_tag=$MINOR_VERSION" >> $GITHUB_ENV
           elif [[ $LABEL == "merge-bump-patch" ]]; then
-            echo "next_tag=$PATCH_VERSION" >> $GITHUB_ENVIRONMENT
+            echo "next_tag=$PATCH_VERSION" >> $GITHUB_ENV
           else
             echo "Setting no-bump as no bump label was found"
-            echo "next_tag=$NO_VERSION" >> $GITHUB_ENVIRONMENT
+            echo "next_tag=$NO_VERSION" >> $GITHUB_ENV
           fi
 
       # Merges the underlying PR

--- a/Sources/gen-ir/CompilerCommandRunner.swift
+++ b/Sources/gen-ir/CompilerCommandRunner.swift
@@ -138,10 +138,13 @@ struct CompilerCommandRunner {
 	private func fixup(command: String) -> String {
 		command.unescaped()
 			.replacingOccurrences(of: "\\=", with: "=")
-		// this reduces the output by telling the driver to not output JSON, saves a _lot_ of memory
+			// this reduces the output by telling the driver to not output JSON, saves a _lot_ of memory
 			.replacingOccurrences(of: "-parseable-output ", with: "")
-		// for some reason this throws an error if included?
+			// for some reason this throws an error if included?
 			.replacingOccurrences(of: "-use-frontend-save-temps", with: "")
+			// Clang, if given -fembed-bitcode & -emit-bc will emit.... Textual ASM????
+			// swiftc behaves correctly and ignores the embed flag
+			.replacingOccurrences(of: "-fembed-bitcode", with: "")
 	}
 
 	/// Corrects the compiler arguments by removing options block BC generation and adding options to emit BC


### PR DESCRIPTION
Clang will, rather helpfully, emit textual ASM if both `-fembed-bitcode` & `-emit-bc` are supplied. Remove this flag if present.