### PR TITLE
Fix an issue with paths that contain spaces

### DIFF
--- a/Sources/gen-ir/CompilerCommandRunner.swift
+++ b/Sources/gen-ir/CompilerCommandRunner.swift
@@ -239,6 +239,13 @@ extension CompilerCommandRunner {
 		}
 
 		let path = arguments[index + 1].fileURL
+
+		guard fileManager.fileExists(atPath: path.filePath) else {
+			logger.error("Found an OuputFileMap, but it doesn't exist on disk? Please report this issue.")
+			logger.debug("OutputFileMap path: \(path)")
+			return nil
+		}
+
 		let data = try Data(contentsOf: path)
 		return try JSONDecoder().decode(OutputFileMap.self, from: data)
 	}

--- a/Sources/gen-ir/Extensions/String+Extension.swift
+++ b/Sources/gen-ir/Extensions/String+Extension.swift
@@ -16,7 +16,8 @@ extension String {
 
 	/// Returns a file URL
 	var fileURL: URL {
-		return .init(fileURLWithPath: self)
+		// We have to replace \ in strings otherwise they'll end up encoded into the URL and break resolution for paths with spaces
+		return .init(fileURLWithPath: self.replacingOccurrences(of: "\\", with: ""))
 	}
 
 	/// Returns the first index of a character that hasn't been escaped


### PR DESCRIPTION
If a file path, parsed as a string, contains a `\` character - it will not be ignored when using filesystem APIs and cuase failures as the path won't exist.